### PR TITLE
Fix GitHub Pages base href

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       run: flutter config --enable-web
       
     - name: Build web
-      run: flutter build web --release --base-href "/"
+      run: flutter build web --release --base-href "/local_keep_flutter/"
       
     - name: List build contents
       run: ls -la build/web/


### PR DESCRIPTION
## Summary
- set base href to repo folder when building web release

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c8c0be8e0832391ba3f35a8a34d0d